### PR TITLE
Enh/group constructions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GroupsCore"
 uuid = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
 authors = ["Marek Kaluba <kalmar@amu.edu.pl> and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ incorrect, one needs to redefine it e.g. setting
 
 #### Obligatory methods
  * `Base.one(G::Group)`: return the identity of the group
- * `GroupsCore.order(::Type{I}, G::Group) where I<:Integer`: the order of `G`
+ * `GroupsCore.order(::Type{I}, G::Group) where I`: the order of `G`
 returned as an instance of `I`; only arbitrary size integers are required to
 return mathematically correct answer. An infinite group must throw
 `GroupsCore.InfiniteOrder` exception.
@@ -101,7 +101,7 @@ No further methods are strictly necessary.
 Based on these methods only, the following functions in `GroupsCore` are
 implemented:
  * `Base.one(g::GroupElement)` → `one(parent(g))`
- * `GroupsCore.order(g)`, `order(I::Type{<:Integer}, g)` (naive implementation)
+ * `GroupsCore.order(g)`, `order(::Type{T}, g)` (naive implementation)
  * `Base.literal_pow(::typeof(^), g, Val{-1})` → `inv(g)`
  * `Base.:(/)(g, h)` → `g*h^-1`
  * `Base.conj(g, h)`, `Base.:(^)(g, h)` → `h^-1*g*h`

--- a/docs/src/group_elements.md
+++ b/docs/src/group_elements.md
@@ -5,7 +5,7 @@ of group elements should subtype.
 
 ## Obligatory methods
 
-The elements which are not `isbits` should extend
+The elements which are not of `isbitstype` should extend
 ```julia
 Base.deepcopy_internal(g::GroupElement, ::IdDict)
 ```
@@ -41,7 +41,7 @@ and
 ```@docs
 one(::GroupElement)
 isequal(::GEl, ::GEl) where {GEl <: GroupElement}
-order(::Type{<:Integer}, ::GroupElement)
+order(::Type{T}, ::GroupElement) where T
 conj
 :(^)(::GEl, ::GEl) where {GEl <: GroupElement}
 commutator
@@ -53,7 +53,7 @@ Some of the mentioned implemented methods may be altered for performance
 reasons:
  * [`isequal`](@ref)
  * `Base.:(^)(g::GroupElement, n::Integer)`
- * [`order(::Type{<:Integer}, g::GroupElement)`](@ref)
+ * [`order(::Type{T}, g::GroupElement) where T`](@ref)
  * `Base.hash(::GroupElement, ::UInt)`
 
 ```@docs

--- a/docs/src/groups.md
+++ b/docs/src/groups.md
@@ -31,7 +31,7 @@ implement the `Group` interface.
 
 ```@docs
 one(::Group)
-order(::Type{<:Integer}, ::Group)
+order(::Type{T}, ::Group) where T
 gens(::Group)
 rand
 ```

--- a/src/GroupsCore.jl
+++ b/src/GroupsCore.jl
@@ -50,4 +50,7 @@ include("group_elements.jl")
 
 include("extensions.jl")
 
+include("constructions/constructions.jl")
+using .Constructions
+
 end

--- a/src/GroupsCore.jl
+++ b/src/GroupsCore.jl
@@ -15,36 +15,7 @@ export Group, GroupElement
 export commutator, gens, hasgens, isfiniteorder, ngens, order
 # export one!, inv!, mul!, conj!, commutator!, div_left!, div_right!
 
-struct InterfaceNotImplemented <: Exception
-    family::Symbol
-    method::String
-end
-
-Base.showerror(io::IO, err::InterfaceNotImplemented) =
-    print(io, "Missing method from $(err.family) interface: `$(err.method)`")
-
-struct InfiniteOrder{T} <: Exception
-    x::T
-    msg
-    InfiniteOrder(g::Union{GroupElement, Group}) = new{typeof(g)}(g)
-    InfiniteOrder(g::Union{GroupElement, Group}, msg) = new{typeof(g)}(g, msg)
-end
-
-function Base.showerror(io::IO, err::InfiniteOrder{T}) where T
-    println(io, "Infinite order exception with ", err.x)
-    if isdefined(err, :msg)
-        print(io, err.msg)
-    else
-        print(io, "order will only return a value when it is finite. ")
-        f = if T <: Group
-            "isfinite(G)"
-        elseif T <: GroupElement
-            "isfiniteorder(g)"
-        end
-        print(io, "You should check with `$f` first.")
-    end
-end
-
+include("exceptions.jl")
 include("groups.jl")
 include("group_elements.jl")
 

--- a/src/constructions/constructions.jl
+++ b/src/constructions/constructions.jl
@@ -1,0 +1,10 @@
+module Constructions
+
+using GroupsCore
+import AbstractAlgebra
+
+include("direct_product.jl")
+include("direct_power.jl")
+include("wreath_product.jl")
+
+end # of module Constructions

--- a/src/constructions/direct_power.jl
+++ b/src/constructions/direct_power.jl
@@ -1,0 +1,104 @@
+using Random
+using GroupsCore
+
+struct DirectPower{Gr,N,GEl<:GroupsCore.GroupElement} <: GroupsCore.Group
+    group::Gr
+
+    function DirectPower{N}(G::GroupsCore.Group) where {N}
+        @assert N > 1
+        return new{typeof(G),N,eltype(G)}(G)
+    end
+end
+
+struct DirectPowerElement{GEl,N,Gr<:GroupsCore.Group} <: GroupsCore.GroupElement
+    elts::NTuple{N,GEl}
+    parent::DirectPower{Gr,N,GEl}
+end
+
+DirectPowerElement(
+    elts::AbstractVector{<:GroupsCore.GroupElement},
+    G::DirectPower,
+) = DirectPowerElement(ntuple(i -> elts[i], _nfold(G)), G)
+
+# (G::DirectPower{Gr, N, GEl})(elts::NTuple{GEl}) where {Gr, N, GEl} =
+#     DirectPowerElement(elts, G)
+
+_nfold(::DirectPower{Gr,N}) where {Gr,N} = N
+
+Base.one(G::DirectPower) =
+    DirectPowerElement(ntuple(_ -> one(G.group), _nfold(G)), G)
+
+Base.eltype(::Type{<:DirectPower{Gr,N,GEl}}) where {Gr,N,GEl} =
+    DirectPowerElement{GEl,N,Gr}
+
+function Base.iterate(G::DirectPower)
+    itr = Iterators.ProductIterator(ntuple(i -> G.group, _nfold(G)))
+    res = iterate(itr)
+    @assert !isnothing(res)
+    elt = DirectPowerElement(first(res), G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.iterate(G::DirectPower, state)
+    itr, st = state.iterator, state.state
+    res = iterate(itr, st)
+    res === nothing && return nothing
+    elt = DirectPowerElement(first(res), G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.IteratorSize(::Type{<:DirectPower{Gr,N}}) where {Gr,N}
+    Base.IteratorSize(Gr) isa Base.HasLength && return Base.HasShape{N}()
+    Base.IteratorSize(Gr) isa Base.HasShape && return Base.HasShape{N}()
+    return Base.IteratorSize(Gr)
+end
+
+Base.size(G::DirectPower) = ntuple(_ -> length(G.group), _nfold(G))
+
+GroupsCore.order(::Type{I}, G::DirectPower) where {I<:Integer} =
+    convert(I, order(I, G.group)^_nfold(G))
+
+function GroupsCore.gens(G::DirectPower)
+    itr = Iterators.ProductIterator(ntuple(i -> gens(G.group), _nfold(G)))
+    generators = [DirectPowerElement(elts, G) for elts in itr]
+    return reshape(generators, (length(generators),))
+end
+
+Base.isfinite(G::DirectPower) = isfinite(G.group)
+
+function Base.rand(
+    rng::Random.AbstractRNG,
+    rs::Random.SamplerTrivial{<:DirectPower},
+)
+    G = rs[]
+    return DirectPowerElement(rand(rng, G.group, _nfold(G)), G)
+end
+
+GroupsCore.parent(g::DirectPowerElement) = g.parent
+GroupsCore.parent_type(::Type{DirectPowerElement{GEl,N,Gr}}) where {GEl,N,Gr} =
+    DirectPower{Gr,N,GEl}
+
+Base.:(==)(g::DirectPowerElement, h::DirectPowerElement) =
+    (parent(g) === parent(h) && g.elts == h.elts)
+
+Base.hash(g::DirectPowerElement, h::UInt) = hash(g.elts, hash(parent(g), h))
+
+Base.deepcopy_internal(g::DirectPowerElement, stackdict::IdDict) =
+    DirectPowerElement(Base.deepcopy_internal(g.elts, stackdict), parent(g))
+
+Base.inv(g::DirectPowerElement) = DirectPowerElement(inv.(g.elts), parent(g))
+
+function Base.:(*)(g::DirectPowerElement, h::DirectPowerElement)
+    @assert parent(g) === parent(h)
+    return DirectPowerElement(g.elts .* h.elts, parent(g))
+end
+
+GroupsCore.order(::Type{I}, g::DirectPowerElement) where {I<:Integer} =
+    convert(I, reduce(lcm, (order(I, h) for h in g.elts), init = one(I)))
+
+Base.isone(g::DirectPowerElement) = all(isone, g.elts)
+
+Base.show(io::IO, G::DirectPower) =
+    print(io, "Direct $(_nfold(G))-th power of $(G.group)")
+Base.show(io::IO, g::DirectPowerElement) =
+    print(io, "( ", join(g.elts, ", "), " )")

--- a/src/constructions/direct_product.jl
+++ b/src/constructions/direct_product.jl
@@ -1,0 +1,104 @@
+using Random
+using GroupsCore
+
+struct DirectProduct{Gt,Ht,GEl,HEl} <: GroupsCore.Group
+    first::Gt
+    last::Ht
+
+    function DirectProduct(G::GroupsCore.Group, H::GroupsCore.Group)
+        return new{typeof(G),typeof(H),eltype(G),eltype(H)}(G, H)
+    end
+end
+
+struct DirectProductElement{GEl,HEl,Gt,Ht} <: GroupsCore.GroupElement
+    elts::Tuple{GEl,HEl}
+    parent::DirectProduct{Gt,Ht,GEl,HEl}
+end
+
+DirectProductElement(g, h, G::DirectProduct) = DirectProduct((g, h), G)
+
+Base.one(G::DirectProduct) =
+    DirectProductElement((one(G.first), one(G.last)), G)
+
+Base.eltype(::Type{<:DirectProduct{Gt,Ht,GEl,HEl}}) where {Gt,Ht,GEl,HEl} =
+    DirectProductElement{GEl,HEl,Gt,Ht}
+
+function Base.iterate(G::DirectProduct)
+    itr = Iterators.product(G.first, G.last)
+    res = iterate(itr)
+    @assert !isnothing(res)
+    elt = DirectProductElement(first(res), G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.iterate(G::DirectProduct, state)
+    itr, st = state.iterator, state.state
+    res = iterate(itr, st)
+    res === nothing && return nothing
+    elt = DirectProductElement(first(res), G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.IteratorSize(::Type{<:DirectProduct{Gt,Ht}}) where {Gt,Ht}
+    Gi = Base.IteratorSize(Gt)
+    Hi = Base.IteratorSize(Ht)
+    if Gi isa Base.IsInfinite || Hi isa Base.IsInfinite
+        return Base.IsInfinite()
+    elseif Gi isa Base.SizeUnknown || Hi isa Base.SizeUnknown
+        return Base.SizeUnknown()
+    else
+        return Base.HasShape{2}()
+    end
+end
+
+Base.size(G::DirectProduct) = (length(G.first), length(G.last))
+
+GroupsCore.order(::Type{I}, G::DirectProduct) where {I<:Integer} =
+    convert(I, order(I, G.first) * order(I, G.last))
+
+function GroupsCore.gens(G::DirectProduct)
+    itr = Iterators.product(gens(G.first), gens(G.last))
+    generators = [DirectProductElement(elts, G) for elts in itr]
+    return reshape(generators, (length(generators),))
+end
+
+Base.isfinite(G::DirectProduct) = isfinite(G.first) && isfinite(G.last)
+
+function Base.rand(
+    rng::Random.AbstractRNG,
+    rs::Random.SamplerTrivial{<:DirectProduct},
+)
+    G = rs[]
+    return DirectProductElement((rand(rng, G.first), rand(rng, G.last)), G)
+end
+
+GroupsCore.parent(g::DirectProductElement) = g.parent
+GroupsCore.parent_type(
+    ::Type{DirectProductElement{GEl,HEl,Gt,Ht}},
+) where {GEl,HEl,Gt,Ht} = DirectProduct{Gt,Ht,GEl,HEl}
+
+Base.:(==)(g::DirectProductElement, h::DirectProductElement) =
+    (parent(g) === parent(h) && g.elts == h.elts)
+
+Base.hash(g::DirectProductElement, h::UInt) = hash(g.elts, hash(parent(g), h))
+
+Base.deepcopy_internal(g::DirectProductElement, stackdict::IdDict) =
+    DirectProductElement(Base.deepcopy_internal(g.elts, stackdict), parent(g))
+
+Base.inv(g::DirectProductElement) =
+    DirectProductElement(inv.(g.elts), parent(g))
+
+function Base.:(*)(g::DirectProductElement, h::DirectProductElement)
+    @assert parent(g) === parent(h)
+    return DirectProductElement(g.elts .* h.elts, parent(g))
+end
+
+GroupsCore.order(::Type{I}, g::DirectProductElement) where {I<:Integer} =
+    convert(I, lcm(order(I, first(g.elts)), order(I, last(g.elts))))
+
+Base.isone(g::DirectProductElement) = all(isone, g.elts)
+
+Base.show(io::IO, G::DirectProduct) =
+    print(io, "Direct product of $(G.first) and $(G.last)")
+Base.show(io::IO, g::DirectProductElement) =
+    print(io, "( $(join(g.elts, ",")) )")

--- a/src/constructions/wreath_product.jl
+++ b/src/constructions/wreath_product.jl
@@ -131,9 +131,6 @@ function Base.:(*)(g::WreathProductElement, h::WreathProductElement)
     return WreathProductElement(g.n * _act(g.p, h.n), g.p * h.p, parent(g))
 end
 
-GroupsCore.order(::Type{I}, g::WreathProductElement) where {I<:Integer} =
-    convert(I, lcm(order(I, g.n), order(I, g.p)))
-
 Base.isone(g::WreathProductElement) = isone(g.n) && isone(g.p)
 
 Base.show(io::IO, G::WreathProduct) =

--- a/src/constructions/wreath_product.jl
+++ b/src/constructions/wreath_product.jl
@@ -1,0 +1,141 @@
+using Random
+using GroupsCore
+
+import AbstractAlgebra: AbstractPermutationGroup, AbstractPerm, degree
+
+# to be moved to AA:
+AbstractAlgebra.degree(G::AbstractAlgebra.Generic.SymmetricGroup) = G.n
+
+"""
+    WreathProduct(G::Group, P::AbstractPermutationGroup) <: Group
+Return the wreath product of a group `G` by permutation group `P`, usually
+written as `G ≀ P`.
+
+As set `G ≀ P` is the same as `Gᵈ × P` and the group can be understood as a
+semi-direct product of `P` acting on `d`-fold cartesian product of `G` by
+permuting coordinates. To be more precise, the multiplication inside wreath
+product is defined as
+>  `(n, σ) * (m, τ) = (n*(m^σ), σ*τ)`
+where `m^σ` denotes the action (from the right) of the permutation `σ` on
+`d`-tuples of elements from `G`.
+"""
+struct WreathProduct{DP<:DirectPower,PGr<:AbstractPermutationGroup} <:
+       GroupsCore.Group
+    N::DP
+    P::PGr
+
+    function WreathProduct(G::Group, P::AbstractPermutationGroup)
+        N = DirectPower{degree(P)}(G)
+        return new{typeof(N),typeof(P)}(N, P)
+    end
+end
+
+struct WreathProductElement{
+    DPEl<:DirectPowerElement,
+    PEl<:AbstractPerm,
+    Wr<:WreathProduct,
+} <: GroupsCore.GroupElement
+    n::DPEl
+    p::PEl
+    parent::Wr
+
+    function WreathProductElement(
+        n::DirectPowerElement,
+        p::AbstractPerm,
+        W::WreathProduct,
+    )
+        new{typeof(n),typeof(p),typeof(W)}(n, p, W)
+    end
+end
+
+Base.one(W::WreathProduct) = WreathProductElement(one(W.N), one(W.P), W)
+
+Base.eltype(::Type{<:WreathProduct{DP,PGr}}) where {DP,PGr} =
+    WreathProductElement{eltype(DP),eltype(PGr),WreathProduct{DP,PGr}}
+
+function Base.iterate(G::WreathProduct)
+    itr = Iterators.product(G.N, G.P)
+    res = iterate(itr)
+    @assert !isnothing(res)
+    elt = WreathProductElement(first(res)..., G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.iterate(G::WreathProduct, state)
+    itr, st = state.iterator, state.state
+    res = iterate(itr, st)
+    res === nothing && return nothing
+    elt = WreathProductElement(first(res)..., G)
+    return elt, (iterator = itr, state = last(res))
+end
+
+function Base.IteratorSize(::Type{<:WreathProduct{DP,PGr}}) where {DP,PGr}
+    dpI = Base.IteratorSize(DP)
+    pgI = Base.IteratorSize(PGr)
+
+    if dpI isa Base.IsInfinite || pgI isa Base.IsInfinite
+        return Base.IsInfinite()
+    elseif dpI isa Base.SizeUnknown || pgI isa Base.SizeUnknown
+        return Base.SizeUnknown()
+    else
+        return Base.HasShape{2}()
+    end
+end
+
+Base.size(G::WreathProduct) = (length(G.N), length(G.P))
+
+GroupsCore.order(::Type{I}, G::WreathProduct) where {I<:Integer} =
+    convert(I, order(I, G.N) * order(I, G.P))
+
+GroupsCore.gens(G::WreathProduct) =
+    [WreathProductElement(n, p, G) for n in gens(G.N) for p in gens(G.P)]
+
+Base.isfinite(G::WreathProduct) = isfinite(G.N) && isfinite(G.P)
+
+function Base.rand(
+    rng::Random.AbstractRNG,
+    rs::Random.SamplerTrivial{<:WreathProduct},
+)
+
+    G = rs[]
+    return WreathProductElement(rand(rng, G.N), rand(rng, G.P), G)
+end
+
+GroupsCore.parent(g::WreathProductElement) = g.parent
+GroupsCore.parent_type(::Type{WreathProductElement{S,T,Wr}}) where {S,T,Wr} = Wr
+
+Base.:(==)(g::WreathProductElement, h::WreathProductElement) =
+    parent(g) === parent(h) && g.n == h.n && g.p == h.p
+
+Base.hash(g::WreathProductElement, h::UInt) =
+    hash(g.n, hash(g.p, hash(g.parent, h)))
+
+function Base.deepcopy_internal(g::WreathProductElement, stackdict::IdDict)
+    return WreathProductElement(
+        Base.deepcopy_internal(g.n, stackdict),
+        Base.deepcopy_internal(g.p, stackdict),
+        parent(g),
+    )
+end
+
+_act(p::AbstractAlgebra.AbstractPerm, n::DirectPowerElement) =
+    DirectPowerElement(n.elts[p.d], parent(n))
+
+function Base.inv(g::WreathProductElement)
+    pinv = inv(g.p)
+    return WreathProductElement(_act(pinv, inv(g.n)), pinv, parent(g))
+end
+
+function Base.:(*)(g::WreathProductElement, h::WreathProductElement)
+    @assert parent(g) === parent(h)
+    return WreathProductElement(g.n * _act(g.p, h.n), g.p * h.p, parent(g))
+end
+
+GroupsCore.order(::Type{I}, g::WreathProductElement) where {I<:Integer} =
+    convert(I, lcm(order(I, g.n), order(I, g.p)))
+
+Base.isone(g::WreathProductElement) = isone(g.n) && isone(g.p)
+
+Base.show(io::IO, G::WreathProduct) =
+    print(io, "Wreath Product of $(G.N.group) by $(G.P)")
+Base.show(io::IO, g::WreathProductElement) = print(io, "( $(g.n)≀$(g.p) )")

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,29 @@
+struct InterfaceNotImplemented <: Exception
+    family::Symbol
+    method::String
+end
+
+Base.showerror(io::IO, err::InterfaceNotImplemented) =
+    print(io, "Missing method from $(err.family) interface: `$(err.method)`")
+
+struct InfiniteOrder{T} <: Exception
+    x::T
+    msg
+    InfiniteOrder(g::Union{GroupElement, Group}) = new{typeof(g)}(g)
+    InfiniteOrder(g::Union{GroupElement, Group}, msg) = new{typeof(g)}(g, msg)
+end
+
+function Base.showerror(io::IO, err::InfiniteOrder{T}) where T
+    println(io, "Infinite order exception with ", err.x)
+    if isdefined(err, :msg)
+        print(io, err.msg)
+    else
+        print(io, "order will only return a value when it is finite. ")
+        f = if T <: Group
+            "isfinite(G)"
+        elseif T <: GroupElement
+            "isfiniteorder(g)"
+        end
+        print(io, "You should check with `$f` first.")
+    end
+end

--- a/src/extensions.jl
+++ b/src/extensions.jl
@@ -1,3 +1,5 @@
+_is_deepcopiable(g::GroupElement) = !isbits(g)
+
 function isabelian end
 function issolvable end
 function isnilpotent end

--- a/src/group_elements.jl
+++ b/src/group_elements.jl
@@ -94,7 +94,7 @@ Return the identity element in the group of $g$.
 Base.one(g::GroupElement) = one(parent(g))
 
 @doc Markdown.doc"""
-    order(::Type{I} = BigInt, g::GroupElement) where {I <: Integer}
+    order(::Type{T} = BigInt, g::GroupElement) where T
 
 Return the order of $g$ as an instance of `I`. If $g$ is of infinite order
 `GroupsCore.InfiniteOrder` exception will be thrown.
@@ -104,14 +104,14 @@ Return the order of $g$ as an instance of `I`. If $g$ is of infinite order
     Only arbitrary sized integers are required to return a mathematically
     correct answer.
 """
-function order(::Type{I}, g::GroupElement) where {I<:Integer}
+function order(::Type{T}, g::GroupElement) where T
     isfiniteorder(g) || throw(InfiniteOrder(g))
-    isone(g) && return I(1)
-    o = I(1)
+    isone(g) && return T(1)
+    o = T(1)
     gg = deepcopy(g)
     out = similar(g)
     while !isone(gg)
-        o += I(1)
+        o += T(1)
         gg = mul!(out, gg, g)
     end
     return o

--- a/src/group_elements.jl
+++ b/src/group_elements.jl
@@ -39,18 +39,6 @@ Base.:(==)(g::GEl, h::GEl) where {GEl <: GroupElement} = throw(
     InterfaceNotImplemented(:Group, "Base.:(==)(::$GEl, ::$GEl)"),
 )
 
-@doc Markdown.doc"""
-    isfiniteorder(g::GroupElement)
-
-Return `true` if $g$ is of finite order, possibly without computing it.
-"""
-function isfiniteorder(g::GroupElement)
-    isfinite(parent(g)) && return true
-    throw(
-        InterfaceNotImplemented(:Group, "GroupsCore.isfiniteorder(::$(typeof(g)))"),
-    )
-end
-
 Base.deepcopy_internal(g::GroupElement, stackdict::IdDict) = throw(
     InterfaceNotImplemented(
         :Group,
@@ -81,6 +69,18 @@ Base.:(*)(g::GEl, h::GEl) where {GEl <: GroupElement} = throw(
         "Base.:(*)(::$(typeof(g)), ::$(typeof(g)))",
     ),
 )
+
+@doc Markdown.doc"""
+    isfiniteorder(g::GroupElement)
+
+Return `true` if $g$ is of finite order, possibly without computing it.
+"""
+function isfiniteorder(g::GroupElement)
+    isfinite(parent(g)) && return true
+    throw(
+        InterfaceNotImplemented(:Group, "GroupsCore.isfiniteorder(::$(typeof(g)))"),
+    )
+end
 
 ################################################################################
 # Default implementations

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -15,9 +15,9 @@ Base.one(G::Group) =
     throw(InterfaceNotImplemented(:Group, "Base.one(::$(typeof(G)))"))
 
 @doc Markdown.doc"""
-    order(I::Type{Integer} = BigInt, G::Group)
+    order(::Type{T} = BigInt, G::Group) where T
 
-Return the order of $G$ as an instance of `I`. If $G$ is of infinite order,
+Return the order of $G$ as an instance of `T`. If $G$ is of infinite order,
 `GroupsCore.InfiniteOrder` exception will be thrown.
 
 !!! warning
@@ -25,14 +25,14 @@ Return the order of $G$ as an instance of `I`. If $G$ is of infinite order,
     Only arbitrary sized integers are required to return a mathematically
     correct answer.
 """
-function order(::Type{<:Integer}, G::Group)
+function order(::Type{T}, G::Group) where T
     if !isfinite(G)
         throw(InfiniteOrder(G))
     end
     throw(
         InterfaceNotImplemented(
             :Group,
-            "GroupsCore.order(::Type{<:Integer}, ::$(typeof(G)))",
+            "GroupsCore.order(::Type{$T}, ::$(typeof(G)))",
         )
     )
 end

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -161,5 +161,5 @@ function ngens(G::Group)
     )
 end
 
-pseudo_rand(G::Group, args...) = pseudo_rand(Random.default_rng(), G, args...)
-pseudo_rand(rng::Random.AbstractRNG, G::Group, args...) = rand(rng, G, args...)
+rand_pseudo(G::Group, args...) = rand_pseudo(Random.default_rng(), G, args...)
+rand_pseudo(rng::Random.AbstractRNG, G::Group, args...) = rand(rng, G, args...)

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -175,7 +175,7 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
                 @test order(inv(g)) == order(g)
                 @test order(one(g)) == 1
             else
-                @test_throws InfiniteOrder order(g)
+                @test_throws GroupsCore.InfiniteOrder order(g)
             end
 
             @test similar(g) isa typeof(g)

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -65,12 +65,11 @@ end
 
 function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
 
-    @assert parent(g) === parent(h)
-
     @testset "GroupElement interface" begin
 
         @testset "Parent methods" begin
             @test parent(g) isa Group
+            @test parent(g) === parent(h)
             G = parent(g)
 
             @test eltype(G) == typeof(g)

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -6,7 +6,7 @@ function test_Group_interface(G::Group)
             IS = Base.IteratorSize(typeof(G))
             if IS isa Base.HasLength || IS isa Base.HasShape
                 @test isfinite(G) == true
-                @test length(G) isa Integer
+                @test length(G) isa Int
                 @test length(G) > 0
 
                 @test eltype(G) <: GroupElement
@@ -43,14 +43,10 @@ function test_Group_interface(G::Group)
         @testset "order, rand" begin
             if isfinite(G)
                 @test order(Int16, G) isa Int16
-                @test order(G) isa Integer
+                @test order(BigInt, G) isa BigInt
                 @test order(G) >= 1
             else
-                @test try
-                    order(G) isa Integer
-                catch err
-                    err isa GroupsCore.InfiniteOrder
-                end
+                @test_throws GroupsCore.InfiniteOrder order(G)
             end
 
             @test rand(G) isa GroupElement
@@ -164,10 +160,10 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
             @test isfiniteorder(g) isa Bool
 
             if isfiniteorder(g)
-                @test order(g) isa Integer
                 @test order(Int16, g) isa Int16
+                @test order(BigInt, g) isa BigInt
                 @test order(g) >= 1
-                @test iszero(rem(order(parent(g)), order(g)))
+                @test iszero(order(parent(g)) % order(g))
 
                 if !isone(g) && !isone(g^2)
                     @test order(g) > 2

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -169,7 +169,7 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
                 @test order(g) >= 1
                 @test iszero(rem(order(parent(g)), order(g)))
 
-                if g^2 != one(g)
+                if !isone(g) && !isone(g^2)
                     @test order(g) > 2
                 end
                 @test order(inv(g)) == order(g)

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -58,10 +58,10 @@ function test_Group_interface(G::Group)
             g, h = rand(G, 2)
             @test parent(g) === parent(h) === G
 
-            @test GroupsCore.pseudo_rand(G) isa eltype(G)
-            @test GroupsCore.pseudo_rand(G, 2, 2) isa AbstractMatrix{eltype(G)}
+            @test GroupsCore.rand_pseudo(G) isa eltype(G)
+            @test GroupsCore.rand_pseudo(G, 2, 2) isa AbstractMatrix{eltype(G)}
 
-            g, h = GroupsCore.pseudo_rand(G, 2)
+            g, h = GroupsCore.rand_pseudo(G, 2)
             @test parent(g) === parent(h) === G
         end
     end

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -80,7 +80,7 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
 
             @test one(G) == one(g) == one(h)
 
-            if !isbits(g)
+            if GroupsCore._is_deepcopiable(g)
                 @test one(G) !== one(g)
             end
 
@@ -100,7 +100,7 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
 
             @test deepcopy(g) isa typeof(g)
             @test deepcopy(g) == g
-            if !isbits(g)
+            if GroupsCore._is_deepcopiable(g)
                 @test deepcopy(g) !== g
             end
             k = deepcopy(g)

--- a/test/infinite_cyclic.jl
+++ b/test/infinite_cyclic.jl
@@ -1,0 +1,44 @@
+struct InfCyclicGroup <: GroupsCore.Group end
+
+struct InfCyclicGroupElement <: GroupsCore.GroupElement
+    val::BigInt # not isbits
+    InfCyclicGroupElement(i::Integer) = new(convert(BigInt, i))
+end
+
+Base.one(C::InfCyclicGroup) = InfCyclicGroupElement(0)
+
+Base.eltype(::Type{InfCyclicGroup}) = InfCyclicGroupElement
+Base.iterate(C::InfCyclicGroup) = one(C), 0
+function Base.iterate(C::InfCyclicGroup, state)
+    state > 0 && return InfCyclicGroupElement(-state), -state
+    return InfCyclicGroupElement(state+1), state+1
+end
+Base.IteratorSize(::Type{InfCyclicGroup}) = Base.IsInfinite()
+
+GroupsCore.gens(C::InfCyclicGroup) = [InfCyclicGroupElement(1)]
+
+function Base.rand(
+    rng::Random.AbstractRNG,
+    rs::Random.SamplerTrivial{<:InfCyclicGroup},
+)
+    return InfCyclicGroupElement(rand(Int))
+end
+
+GroupsCore.parent(c::InfCyclicGroupElement) = InfCyclicGroup()
+GroupsCore.parent_type(::Type{InfCyclicGroupElement}) = InfCyclicGroup
+Base.:(==)(g::InfCyclicGroupElement, h::InfCyclicGroupElement) = g.val == h.val
+
+# since InfCyclicGroupElement is NOT isbits, we need to define
+Base.deepcopy_internal(g::InfCyclicGroupElement, ::IdDict) =
+    InfCyclicGroupElement(deepcopy(g.val))
+
+Base.inv(g::InfCyclicGroupElement) = InfCyclicGroupElement(-g.val)
+
+Base.:(*)(g::InfCyclicGroupElement, h::InfCyclicGroupElement) =
+    InfCyclicGroupElement(g.val + h.val)
+
+GroupsCore.isfiniteorder(g::InfCyclicGroupElement) = isone(g) ? true : false
+
+# Some eye-candy if you please
+Base.show(io::IO, C::InfCyclicGroup) = print(io, "Infinite cyclic group")
+Base.show(io::IO, c::InfCyclicGroupElement) = print(io, c.val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,12 @@
 using GroupsCore
 using Test
+import AbstractAlgebra
+include("symmetric.jl")
 
 include("conformance_test.jl")
 
 include("cyclic.jl")
 include("infinite_cyclic.jl")
-include("symmetric.jl")
 
 @testset "GroupsCore.jl" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 include("conformance_test.jl")
 
 include("cyclic.jl")
+include("infinite_cyclic.jl")
 include("symmetric.jl")
 
 @testset "GroupsCore.jl" begin
@@ -12,6 +13,12 @@ include("symmetric.jl")
 
     @testset "Cyclic(12)" begin
         G = CyclicGroup(12)
+        test_Group_interface(G)
+        test_GroupElement_interface(rand(G, 2)...)
+    end
+
+    @testset "InfCyclic" begin
+        G = InfCyclicGroup()
         test_Group_interface(G)
         test_GroupElement_interface(rand(G, 2)...)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,3 +31,35 @@ include("symmetric.jl")
 
     include("extensions.jl")
 end
+
+@testset "GroupConstructions" begin
+
+    @testset "DirectProduct" begin
+        GH =
+            let G = AbstractAlgebra.SymmetricGroup(3),
+                H = AbstractAlgebra.SymmetricGroup(4)
+
+                GroupsCore.Constructions.DirectProduct(G, H)
+            end
+        test_Group_interface(GH)
+        test_GroupElement_interface(rand(GH, 2)...)
+    end
+
+    @testset "DirectPower" begin
+        GGG = GroupsCore.Constructions.DirectPower{3}(
+            AbstractAlgebra.SymmetricGroup(3),
+        )
+        test_Group_interface(GGG)
+        test_GroupElement_interface(rand(GGG, 2)...)
+    end
+    @testset "WreathProduct" begin
+        W =
+            let G = AbstractAlgebra.SymmetricGroup(2),
+                P = AbstractAlgebra.SymmetricGroup(4)
+
+                GroupsCore.Constructions.WreathProduct(G, P)
+            end
+        test_Group_interface(W)
+        test_GroupElement_interface(rand(W, 2)...)
+    end
+end

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -13,6 +13,9 @@ GroupsCore.order(
 ) where {I<:Integer} =
     I(foldl(lcm, length(c) for c in AbstractAlgebra.cycles(g)))
 
+# correct the AA length:
+Base.length(G::AbstractAlgebra.Generic.SymmetricGroup) = order(Int, G)
+
 # genuinely new methods:
 Base.IteratorSize(::Type{<:AbstractAlgebra.AbstractPermutationGroup}) = Base.HasLength()
 

--- a/test/test_notsatisfied.jl
+++ b/test/test_notsatisfied.jl
@@ -9,19 +9,38 @@ struct SomeGroupElement <: GroupElement
     elts::Vector{Int} # SomeGroupElement is not isbits anymore
 end
 
-@testset "SomeGroup: No interface implemented" begin
-
+@testset "Exceptions" begin
     @testset "InterfaceNotImplemented exception" begin
         @test GroupsCore.InterfaceNotImplemented(
             :Castle,
             "Aaaaarghhhhh....",
         ) isa Exception
-        ex = GroupsCore.InterfaceNotImplemented(:Castle, "Aaaaarghhhhh....")
+        ex = GroupsCore.InterfaceNotImplemented(:Castle, "Aaargh...")
         @test ex isa GroupsCore.InterfaceNotImplemented
 
         @test sprint(showerror, ex) ==
-              "Missing method from Castle interface: `Aaaaarghhhhh....`"
+              "Missing method from Castle interface: `Aaargh...`"
     end
+
+    @testset "InfiniteOrder" begin
+        G = SomeGroup()
+        @test contains(
+            sprint(showerror, GroupsCore.InfiniteOrder(G)),
+            "isfinite",
+        )
+        g = SomeGroupElement(Int[1, 2, 3])
+        @test contains(
+            sprint(showerror, GroupsCore.InfiniteOrder(g)),
+            "isfiniteorder",
+        )
+        @test contains(
+            sprint(showerror, GroupsCore.InfiniteOrder(g, "Aaargh...")),
+            "Aaargh...",
+        )
+    end
+end
+
+@testset "SomeGroup: No interface implemented" begin
 
     INI = GroupsCore.InterfaceNotImplemented
     InfO = GroupsCore.InfiniteOrder

--- a/test/test_notsatisfied.jl
+++ b/test/test_notsatisfied.jl
@@ -9,6 +9,10 @@ struct SomeGroupElement <: GroupElement
     elts::Vector{Int} # SomeGroupElement is not isbits anymore
 end
 
+if VERSION < v"1.5.0"
+    contains(haystack, needle) = occursin(needle, haystack)
+end
+
 @testset "Exceptions" begin
     @testset "InterfaceNotImplemented exception" begin
         @test GroupsCore.InterfaceNotImplemented(
@@ -21,7 +25,6 @@ end
         @test sprint(showerror, ex) ==
               "Missing method from Castle interface: `Aaargh...`"
     end
-
     @testset "InfiniteOrder" begin
         G = SomeGroup()
         @test contains(

--- a/test/test_notsatisfied.jl
+++ b/test/test_notsatisfied.jl
@@ -78,7 +78,7 @@ end
         @test_throws INI gens(G, 1)
         @test_throws INI ngens(G)
 
-        @test_throws INI GroupsCore.pseudo_rand(G, 2, 2)
+        @test_throws INI GroupsCore.rand_pseudo(G, 2, 2)
     end
 
     @testset "GroupElem Interface" begin


### PR DESCRIPTION
@fingolfin @ThomasBreuer

Judging from these examples we do have quite some boilerplate code that needs to be written... (but it's not that bad either ;)

* added `InfCyclicGroup` examples to tests
* added various generic constructions (to see how the interface works in practice)
* renamed `pseudo_rand` to `rand_pseudo` to keep it aligned with Oscar. We should decide if we want this to be exported at some point