### PR TITLE
Add istrivial

### DIFF
--- a/docs/src/groups.md
+++ b/docs/src/groups.md
@@ -73,11 +73,7 @@ mathematically correct fallback. If your group is finite by definition,
 implementing the correct `IteratorSize` (i.e. `Base.HasLength()`, or
 `Base.HasShape{N}()`) will simplify several other methods, which will be then
 optimized to work only based on the type of the group. In particular when the
-information is derivable from the type, there is no need to extend
-
-```@docs
-Base.isfinite(G::Group)
-```
+information is derivable from the type, there is no need to extend `Base.isfinite`
 
 !!! note
     In the case that `IteratorSize(Gr) == IsInfinite()`, one should define
@@ -86,3 +82,10 @@ Base.isfinite(G::Group)
     For practical reasons the largest group you could iterate over in your
     lifetime is of order that fits into an `Int`. For example, $2^{63}$
     nanoseconds comes to 290 years.
+
+## Additional methods
+
+```@docs
+Base.isfinite(G::Group)
+istrivial(G::Group)
+```

--- a/docs/src/groups.md
+++ b/docs/src/groups.md
@@ -73,7 +73,7 @@ mathematically correct fallback. If your group is finite by definition,
 implementing the correct `IteratorSize` (i.e. `Base.HasLength()`, or
 `Base.HasShape{N}()`) will simplify several other methods, which will be then
 optimized to work only based on the type of the group. In particular when the
-information is derivable from the type, there is no need to extend `Base.isfinite`
+information is derivable from the type, there is no need to extend [`Base.isfinite`](@ref).
 
 !!! note
     In the case that `IteratorSize(Gr) == IsInfinite()`, one should define

--- a/src/GroupsCore.jl
+++ b/src/GroupsCore.jl
@@ -13,6 +13,7 @@ const GroupElement = AbstractAlgebra.GroupElem
 
 export Group, GroupElement
 export commutator, gens, hasgens, isfiniteorder, ngens, order
+export istrivial
 # export one!, inv!, mul!, conj!, commutator!, div_left!, div_right!
 
 include("exceptions.jl")

--- a/src/groups.jl
+++ b/src/groups.jl
@@ -143,6 +143,19 @@ function Base.isfinite(G::Group)
 You need to implement `Base.isfinite(::$(typeof(G))) yourself."""))
 end
 
+
+@doc Markdown.doc"""
+    istrivial(G::Group)
+Test whether group $G$ is trivial.
+
+The default implementation is based on `isfinite` and `order`.
+"""
+function istrivial(G::Group)
+    hasgens(G) && return all(isone, gens(G))
+    isfinite(G) && return isone(order(G))
+    return false
+end
+
 hasgens(G::Group) = true
 
 function gens(G::Group, i::Integer)

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -45,8 +45,10 @@ function test_Group_interface(G::Group)
                 @test order(Int16, G) isa Int16
                 @test order(BigInt, G) isa BigInt
                 @test order(G) >= 1
+                @test istrivial(G) == (order(G) == 1)
             else
                 @test_throws GroupsCore.InfiniteOrder order(G)
+                @test !istrivial(G)
             end
 
             @test rand(G) isa GroupElement


### PR DESCRIPTION
Testing whether a group is trivial can often be done much more
efficiently than computing it size. E.g. by testing if all
generators are the identity.

For now I still chose to use `isfinite`﻿and `order` for the default
implementation as that is more straightforward. It also works for groups that
are infinitely generated

In the end, there is no optimal default implementation anyway;
to get even close, one needs many more concepts, like tests for...
- is the order already known (then use it)
- are generators known, and are there finitely many, and can `isone`
  be computed for them? then do so?
- is the order unknown, but in principle computable? then do so and use it!
- are the generators unknown, but computable? then do so and use it!

But that's for future generations :-) 