### PR TITLE
CI: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: ./lcov.info
           flags: unittests


### PR DESCRIPTION
v1 will be disabled February 1, 2022; see https://github.com/codecov/codecov-action
