### PR TITLE
v0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GroupsCore"
 uuid = "d5909c97-4eac-4ecc-a3dc-fdd0858a4120"
-authors = ["Marek Kaluba <kalmar@amu.edu.pl> and contributors"]
-version = "0.4.0"
+authors = ["Marek Kaluba <kalmar@mailbox.org> and contributors"]
+version = "0.4.1"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/group_elements.jl
+++ b/src/group_elements.jl
@@ -38,6 +38,8 @@ Base.deepcopy_internal(g::GroupElement, stackdict::IdDict) = throw(
 # or a singleton). However by defining this fallback we force everybody to
 # implement it, except isbits group elements.
 
+Base.copy(g::GroupElement) = deepcopy(g)
+
 @doc Markdown.doc"""
     inv(g::GroupElement)
 

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -129,6 +129,12 @@ function test_GroupElement_interface(g::GEl, h::GEl) where {GEl<:GroupElement}
             @test g^-3 == inv(g) * inv(g) * inv(g)
             @test (g, h) == (old_g, old_h)
 
+            pow(g,n) = g^n
+
+            @test pow(g, 6) isa GroupElement
+            @test pow(g, 1) isa GroupElement
+            @test (g, h) == (old_g, old_h)
+
             @test (g * h)^-1 == inv(h) * inv(g)
             @test (g, h) == (old_g, old_h)
 


### PR DESCRIPTION
this contains a small change that cropped up in my usage: enabling using g^n for small non-literals.

CC: @fingolfin @lgoettgens