### PR TITLE
Fix conformance test for trivial group

### DIFF
--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -33,7 +33,11 @@ function test_Group_interface(G::Group)
                     if GroupsCore.hasgens(G)
                         @test first(iterate(G)) isa eltype(G)
                         _, s = iterate(G)
-                        @test first(iterate(G, s)) isa eltype(G)
+                        if length(G) == 1
+                            @test isnothing(iterate(G, s))
+                        else
+                            @test first(iterate(G, s)) isa eltype(G)
+                        end
                         @test isone(first(G))
                     end
                 end

--- a/test/conformance_test.jl
+++ b/test/conformance_test.jl
@@ -33,7 +33,7 @@ function test_Group_interface(G::Group)
                     if GroupsCore.hasgens(G)
                         @test first(iterate(G)) isa eltype(G)
                         _, s = iterate(G)
-                        if length(G) == 1
+                        if GroupsCore.istrivial(G) == 1
                             @test isnothing(iterate(G, s))
                         else
                             @test first(iterate(G, s)) isa eltype(G)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,12 @@ include("infinite_cyclic.jl")
 
     include("test_notsatisfied.jl")
 
+    @testset "Cyclic(1)" begin
+        G = CyclicGroup(1)
+        test_Group_interface(G)
+        test_GroupElement_interface(rand(G, 2)...)
+    end
+
     @testset "Cyclic(12)" begin
         G = CyclicGroup(12)
         test_Group_interface(G)


### PR DESCRIPTION
At one place, the conformance test assumes the existence of two distinct group elements. This test should be skipped for the trivial group.
Furthermore, enables testing with the trivial group to catch similar errors in the future.

It would be great to get this released in the near future, so I can use it in https://github.com/oscar-system/Oscar.jl/pull/3070.